### PR TITLE
Updated all packages in counter dapp to newest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Counter DApp
 
 [![Generic badge](https://img.shields.io/badge/Compact%20Compiler-0.22.0-1abc9c.svg)](https://shields.io/)  
-[![Generic badge](https://img.shields.io/badge/TypeScript-5.2.2-blue.svg)](https://shields.io/)
+[![Generic badge](https://img.shields.io/badge/TypeScript-5.8.3-blue.svg)](https://shields.io/)
 
 ## Prerequisites
 
 1. You must have NodeJS version 22 installed.
-2. Download the latest version of the Compact compiler from [the compiler release page](https://docs.midnight.network/relnotes/compact) and follow the instructions to install it.
+2. Download the latest version of the Compact compiler from [the compiler release page](https://docs.midnight.network/relnotes/compact) and follow the instructions to install it (in particular the instructions regarding permissions that must be set to compile the contracts).
 3. Create a directory for the compiler executables, and unzip the downloaded file into that directory.
 4. Add the directory to your shell's $PATH.
 
@@ -15,6 +15,9 @@
    ```sh
    export PATH=$PATH:$HOME/bin/compactc
    ```
+
+5. Run `npm install` to install all the packages you will need.
+6. Compile and build the code in the `contract` folder before running the code in the `counter-cli` folder.
 
 ## The counter contract
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,23 @@
    export PATH=$PATH:$HOME/bin/compactc
    ```
 
-5. Run `npm install` to install all the packages you will need.
-6. Compile and build the code in the `contract` folder before running the code in the `counter-cli` folder.
+5. Run `npm install` to install all the necessary packages.
+6. Compile and build the code in the `contract` folder before running the code in the `counter-cli` folder.  
+   In the `contract` folder, run this command:
+
+   ```sh
+   npm run compact && npm run build
+   ```
+
+   Follow the instructions in the documentation [to install and launch the proof server](https://docs.midnight.network/develop/tutorial/using/proof-server).
+
+7. Switch to the `counter-cli` folder and run this command:
+
+   ```sh
+   npm run start-testnet-remote
+   ```
+
+   If you do not have a wallet yet, you will be given the option to create a new one. After getting your address, you can use the [official faucet](https://faucet.testnet-02.midnight.network/) to request coins to deploy a contract on testnet and interact with it.
 
 ## The counter contract
 
@@ -42,7 +57,7 @@ export circuit increment(): [] {
 }
 ```
 
-To verify that the smart contract operate as expected,
+To verify that the smart contract operates as expected,
 we've provided some unit tests in `contract/src/test/counter.test.ts`.
 
 We've also provided tests that use a simple simulator, which illustrates
@@ -134,6 +149,6 @@ npm run testnet-remote-ps
 
 Then follow the instructions from the CLI.
 
-If you did not previously created and funded a Midnight Lace wallet, you will need to do so. Funds for testing can be requested from [the official faucet](https://faucet.testnet-02.midnight.network/).
+If you did not previously create and fund a Midnight Lace wallet, you will need to do so. Funds for testing can be requested from [the official faucet](https://faucet.testnet-02.midnight.network/).
 
-You can find much more information in part 2 of the [Midnight developer tutorial](https://docs.midnight.network/develop/tutorial/building).
+You can find more information in part 2 of the [Midnight developer tutorial](https://docs.midnight.network/develop/tutorial/building).

--- a/contract/package-lock.json
+++ b/contract/package-lock.json
@@ -9,13 +9,13 @@
         "@jest/globals": "^29.7.0",
         "@midnight-ntwrk/compact-runtime": "^0.7.0",
         "@midnight-ntwrk/ledger": "^3.0.6",
-        "@midnight-ntwrk/midnight-js-network-id": "^0.2.5",
+        "@midnight-ntwrk/midnight-js-network-id": "^1.0.0",
         "@midnight-ntwrk/zswap": "^3.0.6",
         "eslint": "^9.24.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.3.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.2"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1224,9 +1224,9 @@
       "dev": true
     },
     "node_modules/@midnight-ntwrk/midnight-js-network-id": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-network-id/-/midnight-js-network-id-0.2.5.tgz",
-      "integrity": "sha512-ThVIzpZRoZ/lvHwkb+Dw7fXm9ntzvoYOTd49Ph2YleVz6lwEk+3hBOxcgBEUGF9EExSiUvi+eQzT/vx0KOjAWg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-network-id/-/midnight-js-network-id-1.0.0.tgz",
+      "integrity": "sha512-jLV1dJHsXIY/f/q7pjPb3PW2yV1/MPIWeMJo7NOk98gFS0qoTdOqIA0BIPZe4uglq4WrMlBmTgP+HdrVhajPDA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -4680,9 +4680,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/contract/package.json
+++ b/contract/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "compact": "compactc src/counter.compact src/managed/counter",
+    "compact": "compactc --skip-zk src/counter.compact src/managed/counter",
     "test": "jest",
     "test:compile": "npm run compact && jest",
     "prepack": "yarn build",

--- a/contract/package.json
+++ b/contract/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "compact": "compactc --skip-zk src/counter.compact src/managed/counter",
+    "compact": "compactc src/counter.compact src/managed/counter",
     "test": "jest",
     "test:compile": "npm run compact && jest",
     "prepack": "yarn build",
@@ -25,12 +25,12 @@
     "@jest/globals": "^29.7.0",
     "@midnight-ntwrk/compact-runtime": "^0.7.0",
     "@midnight-ntwrk/ledger": "^3.0.6",
-    "@midnight-ntwrk/midnight-js-network-id": "^0.2.5",
+    "@midnight-ntwrk/midnight-js-network-id": "^1.0.0",
     "@midnight-ntwrk/zswap": "^3.0.6",
     "eslint": "^9.24.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.3.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/contract/src/counter.compact
+++ b/contract/src/counter.compact
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pragma compiler_version 0.22.0;
-pragma language_version 0.14.0;
+pragma language_version 0.14;
 
 import CompactStandardLibrary;
 

--- a/contract/src/index.ts
+++ b/contract/src/index.ts
@@ -13,5 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from "./managed/counter/contract/index.cjs";
+export * as Counter from "./managed/counter/contract/index.cjs";
 export * from "./witnesses.js";

--- a/contract/src/test/counter-simulator.ts
+++ b/contract/src/test/counter-simulator.ts
@@ -38,7 +38,9 @@ export class CounterSimulator {
       currentPrivateState,
       currentContractState,
       currentZswapLocalState
-    } = this.contract.initialState(constructorContext({}, "0".repeat(64)));
+    } = this.contract.initialState(
+      constructorContext({ privateCounter: 0 }, "0".repeat(64))
+    );
     this.circuitContext = {
       currentPrivateState,
       currentZswapLocalState,

--- a/contract/src/test/counter.test.ts
+++ b/contract/src/test/counter.test.ts
@@ -34,7 +34,7 @@ describe("Counter smart contract", () => {
     const initialLedgerState = simulator.getLedger();
     expect(initialLedgerState.round).toEqual(0n);
     const initialPrivateState = simulator.getPrivateState();
-    expect(initialPrivateState).toEqual({});
+    expect(initialPrivateState).toEqual({ privateCounter: 0 });
   });
 
   it("increments the counter correctly", () => {
@@ -42,6 +42,6 @@ describe("Counter smart contract", () => {
     const nextLedgerState = simulator.increment();
     expect(nextLedgerState.round).toEqual(1n);
     const nextPrivateState = simulator.getPrivateState();
-    expect(nextPrivateState).toEqual({});
+    expect(nextPrivateState).toEqual({ privateCounter: 0 });
   });
 });

--- a/contract/src/witnesses.ts
+++ b/contract/src/witnesses.ts
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 // This is how we type an empty object.
-export type CounterPrivateState = Record<string, never>;
+export type CounterPrivateState = {
+  privateCounter: number;
+};
 
 export const witnesses = {};

--- a/counter-cli/package-lock.json
+++ b/counter-cli/package-lock.json
@@ -11,23 +11,23 @@
       "dependencies": {
         "@midnight-ntwrk/compact-runtime": "^0.7.0",
         "@midnight-ntwrk/ledger": "^3.0.6",
-        "@midnight-ntwrk/midnight-js-contracts": "^0.2.5",
-        "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^0.2.5",
-        "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^0.2.5",
-        "@midnight-ntwrk/midnight-js-level-private-state-provider": "^0.2.5",
-        "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^0.2.5",
-        "@midnight-ntwrk/midnight-js-types": "^0.2.5",
-        "@midnight-ntwrk/wallet": "^3.7.5",
-        "@midnight-ntwrk/wallet-api": "^3.5.0",
+        "@midnight-ntwrk/midnight-js-contracts": "^1.0.0",
+        "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^1.0.0",
+        "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^1.0.0",
+        "@midnight-ntwrk/midnight-js-level-private-state-provider": "^1.0.0",
+        "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^1.0.0",
+        "@midnight-ntwrk/midnight-js-types": "^1.0.0",
+        "@midnight-ntwrk/wallet": "^4.0.0",
+        "@midnight-ntwrk/wallet-api": "^4.0.0",
         "@midnight-ntwrk/zswap": "^3.0.6",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
-        "ws": "^8.14.2"
+        "ws": "^8.18.1"
       },
       "devDependencies": {
-        "@types/jest": "^29.5.11",
-        "@types/node": "^22.10.2",
-        "@types/ws": "^8.5.9",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.14.0",
+        "@types/ws": "^8.18.1",
         "eslint": "^9.24.0",
         "jest": "^29.7.0",
         "jest-environment-node": "^29.7.0",
@@ -35,9 +35,9 @@
         "jest-html-reporters": "^3.1.7",
         "jest-junit": "^16.0.0",
         "testcontainers": "^10.24.0",
-        "ts-jest": "^29.1.2",
+        "ts-jest": "^29.3.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.2.2"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.4.tgz",
-      "integrity": "sha512-Ot3RaN2M/rhIKDqXBdOVlN0dQbHydUrYJ9lTxkvd6x7W1pAjwduUccfoz2gsO4U9by7oWtRj/ySF0MFNUp+9Aw==",
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.6.tgz",
+      "integrity": "sha512-G6A8uNb13V/Tv4TJQOs5PnxuE5Rf5D2dMnBQcg9mng1Eo4YBecwFEJ0L022mraq/dLB0jD5tiAESOD2bTyJ6gg==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -153,14 +153,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
-      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.10",
-        "@babel/types": "^7.26.10",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -170,13 +170,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
-      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
+      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.5",
+        "@babel/compat-data": "^7.26.8",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -259,27 +259,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
-      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.10"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
-      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.10"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -528,32 +528,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
-      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.10",
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
-      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.0.tgz",
-      "integrity": "sha512-RoV8Xs9eNwiDvhv7M+xcL4PWyRyIXRY/FLp3buU4h1EYfdF7unWUy3dOjPqb3C7rMUewIcqwW850PgS8h1o1yg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
+      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -650,6 +650,19 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint-community/regexpp": {
@@ -1175,29 +1188,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -1317,29 +1307,6 @@
         "node-notifier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/schemas": {
@@ -1528,38 +1495,39 @@
       "integrity": "sha512-dkkzxQ30ZDfImI9hyF1Up0xdGSjd1y02DAayxQ8R55GQePeQ49umGvC02jnfOgACVS8GavV7TH+QPDpNv0VyzA=="
     },
     "node_modules/@midnight-ntwrk/midnight-js-contracts": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-contracts/-/midnight-js-contracts-0.2.5.tgz",
-      "integrity": "sha512-6XqY/hLsxqm87srk1FVUHkCSIS2UpXrEZ9dOV8o/oWMpbVXlpdaK5aREgrCtn9821OV8w0N+8+x793MtWOWoIQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-contracts/-/midnight-js-contracts-1.0.0.tgz",
+      "integrity": "sha512-36FroVmDTsGuhD+IFW9KNEicYUE4zfkrHss9W6T703KlOR2H3dVihDZ4Gvbmz8kP5ocATwi7lB3SxvPtB/Jf0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/midnight-js-network-id": "0.2.5",
-        "@midnight-ntwrk/midnight-js-types": "0.2.5",
-        "@midnight-ntwrk/midnight-js-utils": "0.2.5"
+        "@midnight-ntwrk/midnight-js-network-id": "1.0.0",
+        "@midnight-ntwrk/midnight-js-types": "1.0.0",
+        "@midnight-ntwrk/midnight-js-utils": "1.0.0"
       }
     },
     "node_modules/@midnight-ntwrk/midnight-js-http-client-proof-provider": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-http-client-proof-provider/-/midnight-js-http-client-proof-provider-0.2.5.tgz",
-      "integrity": "sha512-Hbpf3apDUngJESZhKgqkRQcdVtjauNcUxAoSd7pf9hjGv2h6VOc7T8m7Jl4Iy1rhHT5kMMr+MAgP/M71lGg+Eg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-http-client-proof-provider/-/midnight-js-http-client-proof-provider-1.0.0.tgz",
+      "integrity": "sha512-b1gxEE6SuTJgjc56taJIHK44ZtrWqXVaIrYNIURc6vqJj3gqfhP/KYjVblmR49fHEgREv1OkoNdOZueYm2DrDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dao-xyz/borsh": "^5.1.5",
-        "@midnight-ntwrk/midnight-js-network-id": "0.2.5",
-        "@midnight-ntwrk/midnight-js-types": "0.2.5",
+        "@midnight-ntwrk/midnight-js-network-id": "1.0.0",
+        "@midnight-ntwrk/midnight-js-types": "1.0.0",
         "cross-fetch": "^4.0.0",
+        "fetch-retry": "^6.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@midnight-ntwrk/midnight-js-indexer-public-data-provider": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-indexer-public-data-provider/-/midnight-js-indexer-public-data-provider-0.2.5.tgz",
-      "integrity": "sha512-2noQ8+4yzklJ9gjmyWaXHkhczJp3+2j1F3aLsm9xZQggYtMnSrpKrPZOamPm8mlTEtLEE2zgAfMG8ZP2GI266A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-indexer-public-data-provider/-/midnight-js-indexer-public-data-provider-1.0.0.tgz",
+      "integrity": "sha512-MqyJN15piO5k+PxSrjQ1/pz51Y8C4JpcNSqlG73KPZmkrZIWV39n8pTfWJxF6SIrbWqi1+PIvpyxapDIHdUg3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.8.2",
-        "@midnight-ntwrk/midnight-js-network-id": "0.2.5",
-        "@midnight-ntwrk/midnight-js-types": "0.2.5",
+        "@midnight-ntwrk/midnight-js-network-id": "1.0.0",
+        "@midnight-ntwrk/midnight-js-types": "1.0.0",
         "buffer": "^6.0.3",
         "cross-fetch": "^4.0.0",
         "graphql": "^16.8.0",
@@ -1571,49 +1539,49 @@
       }
     },
     "node_modules/@midnight-ntwrk/midnight-js-level-private-state-provider": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-level-private-state-provider/-/midnight-js-level-private-state-provider-0.2.5.tgz",
-      "integrity": "sha512-ADLPTaq77YdFJWK9Ex7kSnycnBG6+r+CFuVrjpF/FpMDGjOFyYcSZxUJLgtk4Mqp+Y8hHbL+rZ4Os14IF/J6Qg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-level-private-state-provider/-/midnight-js-level-private-state-provider-1.0.0.tgz",
+      "integrity": "sha512-3QLyBRtBMYl0IXrFZ1LcDhRkQB7MoGnGYB2gS989ISulayExLYb7SBWLZa4CPG8ezfz6QFKPh3JZTyZQaaEVew==",
       "license": "MIT",
       "dependencies": {
-        "@midnight-ntwrk/midnight-js-types": "0.2.5",
-        "abstract-level": "^1.0.3",
+        "@midnight-ntwrk/midnight-js-types": "1.0.0",
+        "abstract-level": "^2.0.0",
         "buffer": "^6.0.3",
         "fp-ts": "^2.16.1",
         "io-ts": "^2.2.20",
-        "level": "^8.0.0",
+        "level": "^9.0.0",
         "lodash": "^4.17.21",
-        "superjson": "^1.13.1"
+        "superjson": "^2.0.0"
       }
     },
     "node_modules/@midnight-ntwrk/midnight-js-network-id": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-network-id/-/midnight-js-network-id-0.2.5.tgz",
-      "integrity": "sha512-ThVIzpZRoZ/lvHwkb+Dw7fXm9ntzvoYOTd49Ph2YleVz6lwEk+3hBOxcgBEUGF9EExSiUvi+eQzT/vx0KOjAWg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-network-id/-/midnight-js-network-id-1.0.0.tgz",
+      "integrity": "sha512-jLV1dJHsXIY/f/q7pjPb3PW2yV1/MPIWeMJo7NOk98gFS0qoTdOqIA0BIPZe4uglq4WrMlBmTgP+HdrVhajPDA==",
       "license": "Apache-2.0"
     },
     "node_modules/@midnight-ntwrk/midnight-js-node-zk-config-provider": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-node-zk-config-provider/-/midnight-js-node-zk-config-provider-0.2.5.tgz",
-      "integrity": "sha512-PR101nijLtIyNsffO1M1jlFBapErwia2nrefF1CBJ4FBu9ZjlAY323fzLvetldobE4GCXe5g+9iQb08ppDLG4Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-node-zk-config-provider/-/midnight-js-node-zk-config-provider-1.0.0.tgz",
+      "integrity": "sha512-v7VgIL6Ijf8JWvdLNGzD81JvPz5ubrqnh9fLZ3nai/mqlutmIcZ480h/xavTejvImV1B0fnSiNQF6J7cvmex4g==",
       "license": "MIT",
       "dependencies": {
-        "@midnight-ntwrk/midnight-js-types": "0.2.5"
+        "@midnight-ntwrk/midnight-js-types": "1.0.0"
       }
     },
     "node_modules/@midnight-ntwrk/midnight-js-types": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-types/-/midnight-js-types-0.2.5.tgz",
-      "integrity": "sha512-rQenmdLEpkw+/s82Uu8fAt2NmQ99ynoJO+mYJrD42+rEQDCnc8wrxAI4nS8WxggTAjJJf4dgsj4asDpCU6tQFA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-types/-/midnight-js-types-1.0.0.tgz",
+      "integrity": "sha512-Ovua315setpHhxsCYeWNpKN+aH5WGnq0RyQZ3Tdjv8Ph4mo/gDuGo7sMWroWlWR7VrqU3gQUO8Rz/To9N2SVHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "rxjs": "^7.5.0"
       }
     },
     "node_modules/@midnight-ntwrk/midnight-js-utils": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-utils/-/midnight-js-utils-0.2.5.tgz",
-      "integrity": "sha512-PRBKdeLRL6YigfwB6qc+LRcjk8K73EpKFmCBlFRLKTkaq6n7mgH/UEPgKgC101x7daUyvfLZjm9/zRjVMAtbUw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-utils/-/midnight-js-utils-1.0.0.tgz",
+      "integrity": "sha512-ORHIm1nnSmuA9E3kUqZktLzIIqga2ToTJvBYwdODNBjcQyVkD8hdYMBEs/dfNE5/iAbe9J2tKA5wNDIVFd1VuQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@midnight-ntwrk/onchain-runtime": {
@@ -1622,12 +1590,14 @@
       "integrity": "sha512-i/I1H/zQVFcjzCTD3ENa9OT2z7MvIHeqiY7/biBO7YQk/Dme5aYeQUczs/79sDih4fRQoeHNtaNVyZNzN6OBLg=="
     },
     "node_modules/@midnight-ntwrk/wallet": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet/-/wallet-3.7.5.tgz",
-      "integrity": "sha512-q5fX7b4NzDke5f3upQc7aT38kEdWDgna1xzQUxE1U+dPMD5epipK7+CseacwHFBxrha9it0F4XBcOCtdnMK+vw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet/-/wallet-4.0.0.tgz",
+      "integrity": "sha512-C/iq3DE6sAmeIxqd3nI5UhT4H2AkTXZ3q+UKP+rSYekcjyLjsoNRpKdKDtFmfstakMLBdbTMvt0gkownzHa9Ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/wallet-api": "^3.5.0",
+        "@midnight-ntwrk/wallet-api": "^4.0.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^1.0.0",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^1.0.0",
         "@midnight-ntwrk/zswap": "^3.0.6",
         "isomorphic-ws": "^5.0.0",
         "node-fetch": "3.3.2",
@@ -1637,15 +1607,36 @@
       }
     },
     "node_modules/@midnight-ntwrk/wallet-api": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-api/-/wallet-api-3.5.0.tgz",
-      "integrity": "sha512-1ucwit8lfCywkE2ExhlLCbJ9fx+q8QSGlvYWGrBpLEm1roA7BMh6IRIl27Lurl6T2g8EQI8pco23+2+tcDshDA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-api/-/wallet-api-4.0.0.tgz",
+      "integrity": "sha512-v1jbTzVoPh7QbJFgmTk4AxaTtxKMtV7HPMODoyIl2r5JDA3p6INsfsDAUYlE3447saUrj5nDDaD0kOzkli8kng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@midnight-ntwrk/zswap": "^3.0.2"
       },
       "peerDependencies": {
         "rxjs": "7.x"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-address-format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-address-format/-/wallet-sdk-address-format-1.0.0.tgz",
+      "integrity": "sha512-eRW+4x+XJzexPzWj/hE69GR3nYpvxiUqgfNv1a35tzivvJ5gjGzglYPa71S5SH9TNwMCjSnvAoQOYzykGRl9ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/base": "^1.1.9"
+      },
+      "peerDependencies": {
+        "@midnight-ntwrk/zswap": "^3.0.6"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-capabilities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-capabilities/-/wallet-sdk-capabilities-1.0.0.tgz",
+      "integrity": "sha512-GCBgB4iqh2a7MLDU16N+J632SoeEdlWu3cty3vX3CzQukNkXffVupfVgHUGlvoj4XG0l7UTLxKPyTtcM9+K3WA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@midnight-ntwrk/zswap": "^3.0.6"
       }
     },
     "node_modules/@midnight-ntwrk/zswap": {
@@ -1736,6 +1727,15 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1806,9 +1806,9 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1827,9 +1827,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
-      "integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
+      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1848,9 +1848,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.35",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.35.tgz",
-      "integrity": "sha512-P+DCMASlsH+QaKkDpekKrP5pLls767PPs+/LrlVbKnEnY5tMpEUa2C6U4gRsdFZengOqxdCIqy16R22Q3pLB6Q==",
+      "version": "3.3.37",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.37.tgz",
+      "integrity": "sha512-r+IoKpE5MLKaeD8CvoEh39ckWMLHR/+WBMoRQxrkL+apJqEWLMhBHh+93KIfyPWGd6gK7Q21jpoULKgNoRI0YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1922,13 +1922,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+      "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/object-inspect": {
@@ -1938,9 +1938,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ssh2": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.4.tgz",
-      "integrity": "sha512-9JTQgVBWSgq6mAen6PVnrAmty1lqgCMvpfN+1Ck5WRUsyMYPa6qd50/vMJ0y1zkGpOEgLzm8m8Dx/Y5vRouLaA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1958,9 +1958,9 @@
       }
     },
     "node_modules/@types/ssh2/node_modules/@types/node": {
-      "version": "18.19.80",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.80.tgz",
-      "integrity": "sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==",
+      "version": "18.19.86",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
+      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1982,9 +1982,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2070,44 +2070,20 @@
       }
     },
     "node_modules/abstract-level": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
-      "integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-2.0.2.tgz",
+      "integrity": "sha512-pPJixmXk/kTKLB2sSue7o4Uj6TlLD2XfaP2gWZomHVCC6cuUGX/VslQqKG1yZHfXwBb/3lS6oSTMPGzh1P1iig==",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
-        "catering": "^2.1.0",
         "is-buffer": "^2.0.5",
-        "level-supports": "^4.0.0",
+        "level-supports": "^6.0.0",
         "level-transcoder": "^1.0.1",
-        "module-error": "^1.0.1",
-        "queue-microtask": "^1.2.3"
+        "maybe-combine-errors": "^1.0.0",
+        "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/abstract-level/node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+        "node": ">=16"
       }
     },
     "node_modules/acorn": {
@@ -2179,17 +2155,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2493,25 +2466,33 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.1.tgz",
-      "integrity": "sha512-ilQs4fm/l9eMfWY2dY0WCIUplSUp7U0CT1vrqMg1MUdeZl4fypu5UP0XcDBK5WBQPJAKP1b7XEodISmekH/CEg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
+      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "bare-events": "^2.0.0",
+        "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.0.0"
+        "bare-stream": "^2.6.4"
       },
       "engines": {
-        "bare": ">=1.7.0"
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.0.tgz",
-      "integrity": "sha512-BUrFS5TqSBdA0LwHop4OjPJwisqxGy6JsWVqV6qaFoe965qqtaKfDzHY5T2YA1gUL0ZeeQeA+4BBc1FJTcHiPw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -2660,15 +2641,12 @@
       }
     },
     "node_modules/browser-level": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-2.0.0.tgz",
+      "integrity": "sha512-RuYSCHG/jwFCrK+KWA3dLSUNLKHEgIYhO5ORPjJMjCt7T3e+RzpIDmYKWRHxq2pfKGXjlRuEff7y7RESAAgzew==",
       "license": "MIT",
       "dependencies": {
-        "abstract-level": "^1.0.2",
-        "catering": "^2.1.1",
-        "module-error": "^1.0.2",
-        "run-parallel-limit": "^1.1.0"
+        "abstract-level": "^2.0.1"
       }
     },
     "node_modules/browserslist": {
@@ -2809,9 +2787,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001704",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001704.tgz",
-      "integrity": "sha512-+L2IgBbV6gXB4ETf0keSvLr7JUrRVbIaB/lrQ1+z8mRcQiisG5k+lG6O4n6Y5q6f5EuNfaYXKgymucphlEXQew==",
+      "version": "1.0.30001712",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz",
+      "integrity": "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==",
       "dev": true,
       "funding": [
         {
@@ -2828,15 +2806,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/catering": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2896,20 +2865,19 @@
       "license": "MIT"
     },
     "node_modules/classic-level": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
-      "integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-2.0.0.tgz",
+      "integrity": "sha512-ftiMvKgCQK+OppXcvMieDoYlYLYWhScK6yZRFBrrlHQRbm4k6Gr+yDgu/wt3V0k1/jtNbuiXAsRmuAFcD0Tx5Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "abstract-level": "^1.0.2",
-        "catering": "^2.1.0",
+        "abstract-level": "^2.0.0",
         "module-error": "^1.0.1",
         "napi-macros": "^2.2.2",
         "node-gyp-build": "^4.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/cliui": {
@@ -2925,29 +2893,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/co": {
@@ -3145,28 +3090,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cross-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/cross-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/cross-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -3438,9 +3361,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.116",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.116.tgz",
-      "integrity": "sha512-mufxTCJzLBQVvSdZzX1s5YAuXsN1M4tTyYxOOL1TcSKtIzQ9rjIrm7yFK80rN5dwGTePgdoABDSHpuVtRQh0Zw==",
+      "version": "1.5.134",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.134.tgz",
+      "integrity": "sha512-zSwzrLg3jNP3bwsLqWHmS5z2nIOQ5ngMnfMZOWWtXnqqQkPVyOipxK98w+1beLw1TB+EImPNcG8wVP/cLVs2Og==",
       "dev": true,
       "license": "ISC"
     },
@@ -3585,19 +3508,6 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
@@ -3621,19 +3531,6 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.2.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3853,6 +3750,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4018,16 +3921,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/fs-extra/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -4375,6 +4268,29 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -4932,29 +4848,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/jest-junit/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-junit/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -5392,16 +5285,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5469,17 +5352,17 @@
       }
     },
     "node_modules/level": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/level/-/level-8.0.1.tgz",
-      "integrity": "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-9.0.0.tgz",
+      "integrity": "sha512-n+mVuf63mUEkd8NUx7gwxY+QF5vtkibv6fXTGUgtHWLPDaA5/XZjLcI/Q1nQ8k6OttHT6Ezt+7nSEXsRUfHtOQ==",
       "license": "MIT",
       "dependencies": {
-        "abstract-level": "^1.0.4",
-        "browser-level": "^1.0.1",
-        "classic-level": "^1.2.0"
+        "abstract-level": "^2.0.1",
+        "browser-level": "^2.0.0",
+        "classic-level": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
@@ -5487,12 +5370,12 @@
       }
     },
     "node_modules/level-supports": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-6.2.0.tgz",
+      "integrity": "sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/level-transcoder": {
@@ -5655,6 +5538,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/maybe-combine-errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/maybe-combine-errors/-/maybe-combine-errors-1.0.0.tgz",
+      "integrity": "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {
@@ -6189,9 +6081,9 @@
       "license": "MIT"
     },
     "node_modules/pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6461,26 +6353,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -6652,29 +6524,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/run-parallel-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -6946,29 +6795,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/string-length/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-length/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -7000,40 +6826,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -7056,16 +6849,6 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7103,15 +6886,15 @@
       }
     },
     "node_modules/superjson": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.13.3.tgz",
-      "integrity": "sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
+      "integrity": "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==",
       "license": "MIT",
       "dependencies": {
         "copy-anything": "^3.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {
@@ -7264,6 +7047,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
@@ -7277,9 +7066,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.6.tgz",
-      "integrity": "sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.1.tgz",
+      "integrity": "sha512-FT2PIRtZABwl6+ZCry8IY7JZ3xMuppsEV9qFVHOVe8jDzggwUZ9TsM4chyJxL9yi6LvkqcZYU3LmapEE454zBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7291,6 +7080,7 @@
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
         "semver": "^7.7.1",
+        "type-fest": "^4.38.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -7336,6 +7126,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.39.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
+      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-node": {
@@ -7418,10 +7221,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7433,9 +7249,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7446,11 +7262,21 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -7551,6 +7377,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7612,52 +7454,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -7726,9 +7522,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/counter-cli/package.json
+++ b/counter-cli/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "testnet-remote": "node --experimental-specifier-resolution=node dist/counter-cli/src/testnet-remote.js",
+    "testnet-remote": "node --experimental-specifier-resolution=node --loader ts-node/esm dist/counter-cli/src/testnet-remote.js",
     "testnet-remote-ps": "cp -r proof-server-testnet.yml ./dist/counter-cli && node --experimental-specifier-resolution=node dist/counter-cli/src/testnet-remote-start-proof-server.js",
     "testnet-local": "node --experimental-specifier-resolution=node dist/testnet-local.js",
     "standalone": "docker compose -f standalone.yml pull && node --experimental-specifier-resolution=node dist/standalone.js",
@@ -20,23 +20,23 @@
   "dependencies": {
     "@midnight-ntwrk/compact-runtime": "^0.7.0",
     "@midnight-ntwrk/ledger": "^3.0.6",
-    "@midnight-ntwrk/midnight-js-contracts": "^0.2.5",
-    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^0.2.5",
-    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^0.2.5",
-    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^0.2.5",
-    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^0.2.5",
-    "@midnight-ntwrk/midnight-js-types": "^0.2.5",
-    "@midnight-ntwrk/wallet": "^3.7.5",
-    "@midnight-ntwrk/wallet-api": "^3.5.0",
+    "@midnight-ntwrk/midnight-js-contracts": "^1.0.0",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^1.0.0",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^1.0.0",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^1.0.0",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^1.0.0",
+    "@midnight-ntwrk/midnight-js-types": "^1.0.0",
+    "@midnight-ntwrk/wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-api": "^4.0.0",
     "@midnight-ntwrk/zswap": "^3.0.6",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
-    "ws": "^8.14.2"
+    "ws": "^8.18.1"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.11",
-    "@types/node": "^22.10.2",
-    "@types/ws": "^8.5.9",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.14.0",
+    "@types/ws": "^8.18.1",
     "eslint": "^9.24.0",
     "jest": "^29.7.0",
     "jest-environment-node": "^29.7.0",
@@ -44,8 +44,8 @@
     "jest-html-reporters": "^3.1.7",
     "jest-junit": "^16.0.0",
     "testcontainers": "^10.24.0",
-    "ts-jest": "^29.1.2",
+    "ts-jest": "^29.3.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/counter-cli/package.json
+++ b/counter-cli/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "testnet-remote": "node --experimental-specifier-resolution=node --loader ts-node/esm dist/counter-cli/src/testnet-remote.js",
-    "testnet-remote-ps": "cp -r proof-server-testnet.yml ./dist/counter-cli && node --experimental-specifier-resolution=node dist/counter-cli/src/testnet-remote-start-proof-server.js",
+    "testnet-remote-ps": "cp -r proof-server-testnet.yml ./dist/counter-cli && node --experimental-specifier-resolution=node ts-node/esm dist/counter-cli/src/testnet-remote-start-proof-server.js",
     "testnet-local": "node --experimental-specifier-resolution=node dist/testnet-local.js",
     "standalone": "docker compose -f standalone.yml pull && node --experimental-specifier-resolution=node dist/standalone.js",
     "test-api": "docker compose -f standalone.yml pull && DEBUG='testcontainers' NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=8192' jest --passWithNoTests --detectOpenHandles --forceExit -c jest.api.config.ts",

--- a/counter-cli/src/cli.ts
+++ b/counter-cli/src/cli.ts
@@ -55,7 +55,7 @@ const deployOrJoin = async (providers: CounterProviders, rli: Interface): Promis
     const choice = await rli.question(DEPLOY_OR_JOIN_QUESTION);
     switch (choice) {
       case '1':
-        return await api.deploy(providers);
+        return await api.deploy(providers, { privateCounter: 0 });
       case '2':
         return await join(providers, rli);
       case '3':

--- a/counter-cli/src/common-types.ts
+++ b/counter-cli/src/common-types.ts
@@ -13,17 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { type Contract, type Witnesses } from '../../contract/src/managed/counter/contract/index.cjs';
 import type { CounterPrivateState } from '../../contract/src/witnesses';
-import { type MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
-import { type FoundContract } from '@midnight-ntwrk/midnight-js-contracts';
+import { Counter } from '../../contract/src/index';
+import type { ImpureCircuitId, MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
+import type { DeployedContract, FoundContract } from '@midnight-ntwrk/midnight-js-contracts';
 
-export type PrivateStates = {
-  counterPrivateState: CounterPrivateState;
-};
+export type CounterCircuits = ImpureCircuitId<Counter.Contract<CounterPrivateState>>;
 
-export type CounterProviders = MidnightProviders<'increment', PrivateStates>;
+export const CounterPrivateStateId = 'counterPrivateState';
 
-export type CounterContract = Contract<CounterPrivateState, Witnesses<CounterPrivateState>>;
+export type CounterProviders = MidnightProviders<CounterCircuits, typeof CounterPrivateStateId, CounterPrivateState>;
 
-export type DeployedCounterContract = FoundContract<CounterPrivateState, CounterContract>;
+export type CounterContract = Counter.Contract<CounterPrivateState>;
+
+export type DeployedCounterContract = DeployedContract<CounterContract> | FoundContract<CounterContract>;

--- a/counter-cli/src/test/counter.api.test.ts
+++ b/counter-cli/src/test/counter.api.test.ts
@@ -44,7 +44,7 @@ describe('API', () => {
   });
 
   it('should deploy the contract and increment the counter [@slow]', async () => {
-    const counterContract = await api.deploy(providers);
+    const counterContract = await api.deploy(providers, { privateCounter: 0 });
     expect(counterContract).not.toBeNull();
 
     const counter = await api.displayCounterValue(providers, counterContract);


### PR DESCRIPTION
This PR updates the MidnightJS packages to version 1 and the wallet-related packages to version 4.
It also updates various packages used for the dapp, like TypeScript or ws.
A few lines have been added to the README to better guide developers into installing and using the repo.

This PR brings changes in version number requested by Dependabot in PR #33, #28, #27, #26, #25, #24 and #23. 