### PR TITLE
Add Nix flake for Compact compiler

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ jspm_packages/
 
 # Compact
 managed/
+
+# nix
+.direnv
+.nix-bin

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1754393734,
+        "narHash": "sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "Example Counter – Nix flake that provides the Compact compiler per system";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem = f:
+        inputs.nixpkgs.lib.genAttrs supportedSystems (
+          system:
+            f {
+              pkgs = import inputs.nixpkgs { inherit system; };
+              pkgsUnstable = import inputs."nixpkgs-unstable" { inherit system; };
+              inherit system;
+            }
+        );
+    in
+    {
+      devShells = forEachSupportedSystem ({ pkgs, pkgsUnstable, system }:
+        let
+          # Compact compiler release to use
+          compactVersion = "0.24.0";
+
+          # Artifact URLs by host system
+          urlForSystem = {
+            "x86_64-linux" = "https://d3fazakqrumx6p.cloudfront.net/artifacts/compiler/compactc_${compactVersion}/compactc_v${compactVersion}_x86_64-unknown-linux-musl.zip";
+            "x86_64-darwin" = "https://d3fazakqrumx6p.cloudfront.net/artifacts/compiler/compactc_${compactVersion}/compactc_v${compactVersion}_x86_64-apple-darwin.zip";
+            "aarch64-darwin" = "https://d3fazakqrumx6p.cloudfront.net/artifacts/compiler/compactc_${compactVersion}/compactc_v${compactVersion}_aarch64-darwin.zip";
+          };
+
+          # Local bin dir for downloaded tools
+          binDir = ".nix-bin";
+
+          installScript = pkgs.writeShellScript "setup-compactc" ''
+            set -euo pipefail
+            mkdir -p ${binDir}
+            
+            if [ ! -x ${binDir}/compactc ] || [ "$(cat ${binDir}/.compactc-version 2>/dev/null || echo)" != "${compactVersion}" ]; then
+              tmp="$(mktemp -d)"
+              trap 'rm -rf "$tmp"' EXIT
+              curl -fsSL "${urlForSystem.${system}}" -o "$tmp/compactc.zip"
+              unzip -q "$tmp/compactc.zip" -d "$tmp"
+              cp "$tmp"/* ${binDir}/
+              chmod +x ${binDir}/*
+              echo "${compactVersion}" > ${binDir}/.compactc-version
+            fi
+          '';
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [ pkgs.curl pkgs.unzip pkgsUnstable.nodejs pkgs.yarn ];
+            shellHook = ''
+              ${installScript}
+              export PATH="$PWD/${binDir}:$PATH"
+              export ZKIR_BIN="$PWD/${binDir}/zkir"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Adds Nix flake that provides compactc, compactc.bin, and zkir binaries per system.