### PR TITLE
Update package.json to comply with new Compact compiler commands

### DIFF
--- a/contract/package.json
+++ b/contract/package.json
@@ -16,7 +16,7 @@
     }
   },
   "scripts": {
-    "compact": "compact compile src/counter.compact src/managed/counter",
+    "compact": "compactc src/counter.compact src/managed/counter",
     "test": "vitest run",
     "test:compile": "npm run compact && vitest run",
     "build": "rm -rf dist && tsc --project tsconfig.build.json && cp -Rf ./src/managed ./dist/managed && cp ./src/counter.compact ./dist",


### PR DESCRIPTION
I've just been following the Midnight tutorial in the docs, and on [this step](https://docs.midnight.network/develop/tutorial/building/counter-build) I couldn't run the `npm run compact` command. After looking into the `package.json` file, and reading the `compactc --help` docs, I figured for running the command the proposed changes had to be made. Hope it helps!