### PR TITLE
Update build and typecheck scripts to use local Typescript

### DIFF
--- a/contract/package.json
+++ b/contract/package.json
@@ -19,8 +19,8 @@
     "compact": "compact compile src/counter.compact src/managed/counter",
     "test": "vitest run",
     "test:compile": "npm run compact && vitest run",
-    "build": "rm -rf dist && tsc --project tsconfig.build.json && cp -Rf ./src/managed ./dist/managed && cp ./src/counter.compact ./dist",
+    "build": "rm -rf dist && npm run tsc --project tsconfig.build.json && cp -Rf ./src/managed ./dist/managed && cp ./src/counter.compact ./dist",
     "lint": "eslint src",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "npm run tsc -p tsconfig.json --noEmit"
   }
 }


### PR DESCRIPTION
Currently, the `build` and `typecheck` scripts in `contract` directory will invoke the **globally installed** on the user's machine. If the globally installed Typescript is too old, it may throw an error such as:
> Argument for '--target' option must be: 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'esnext'

`es2022` is only allowed from Typescript 4.6 onwards.

To prevent errors, change the scripts to invoke the locally installed Typescript as specified in `package.json`.