### PR TITLE
chore(contract): use compactc in package.json (fixes #1193)

### DIFF
--- a/contract/package.json
+++ b/contract/package.json
@@ -16,9 +16,9 @@
     }
   },
   "scripts": {
-    "compact": "compact compile src/counter.compact src/managed/counter",
+    "compactc": "compactc src/counter.compact src/managed/counter",
     "test": "vitest run",
-    "test:compile": "npm run compact && vitest run",
+    "test:compile": "npm run compactc && vitest run",
     "build": "rm -rf dist && tsc --project tsconfig.build.json && cp -Rf ./src/managed ./dist/managed && cp ./src/counter.compact ./dist",
     "lint": "eslint src",
     "typecheck": "tsc -p tsconfig.json --noEmit"


### PR DESCRIPTION
While following the Midnight docs [Build the counter DApp](https://docs.midnight.network/develop/tutorial/building/counter-build), I noticed the guide uses the compactc compiler. However,  the contract/package.json script invokes compact. This PR updates the contract/package.json to use the compactc compiler so the project matches the documentation and avoids confusion.